### PR TITLE
feat(foxbit): add X-FB-CLIENT identification headers

### DIFF
--- a/cs/ccxt/base/Exchange.Misc.cs
+++ b/cs/ccxt/base/Exchange.Misc.cs
@@ -49,4 +49,10 @@ public partial class Exchange
     //     return null; // stub to implement
     // }
 
+    // returns the version of the ccxt library, e.g. "4.5.54"
+    public virtual object getCcxtVersion()
+    {
+        return ccxtVersion;
+    }
+
 }

--- a/go/v4/exchange_interface.go
+++ b/go/v4/exchange_interface.go
@@ -147,6 +147,7 @@ type ICoreExchange interface {
 	Init(params map[string]any)
 	FetchDeposits(optionalArgs ...any) <-chan any
 	Milliseconds() int64
+	GetCcxtVersion() string
 	ParseNumber(v any, a ...any) any
 	OmitZero(v any) any
 	FetchOHLCV(symbol any, optionalArgs ...any) <-chan any

--- a/go/v4/exchange_metadata.go
+++ b/go/v4/exchange_metadata.go
@@ -2,4 +2,9 @@ package ccxt
 
 var Version string = "4.5.54"
 
+// GetCcxtVersion returns the version of the ccxt library, e.g. "4.5.54"
+func (this *Exchange) GetCcxtVersion() string {
+	return Version
+}
+
 var Exchanges []string = []string{"aftermath", "alpaca", "apex", "arkham", "ascendex", "aster", "backpack", "bequant", "bigone", "binance", "binancecoinm", "binanceus", "binanceusdm", "bingx", "bit2c", "bitbank", "bitbns", "bitfinex", "bitflyer", "bitget", "bithumb", "bitmart", "bitmex", "bitopro", "bitrue", "bitso", "bitstamp", "bitteam", "bittrade", "bitvavo", "blockchaincom", "blofin", "btcbox", "btcmarkets", "btcturk", "bullish", "bybit", "bydfi", "cex", "coinbase", "coinbaseadvanced", "coinbaseexchange", "coinbaseinternational", "coincheck", "coinex", "coinmate", "coinmetro", "coinone", "coinsph", "coinspot", "cryptocom", "cryptomus", "deepcoin", "delta", "deribit", "derive", "digifinex", "dydx", "exmo", "fmfwio", "foxbit", "gate", "gateio", "gemini", "grvt", "hashkey", "hibachi", "hitbtc", "hollaex", "htx", "huobi", "hyperliquid", "independentreserve", "indodax", "kraken", "krakenfutures", "kucoin", "kucoinfutures", "latoken", "lbank", "lighter", "luno", "mercado", "mexc", "modetrade", "myokx", "ndax", "novadax", "okx", "okxus", "onetrading", "oxfun", "p2b", "pacifica", "paradex", "paymium", "phemex", "poloniex", "tokocrypto", "toobit", "upbit", "wavesexchange", "weex", "whitebit", "woo", "woofipro", "xt", "yobit", "zaif", "zebpay"}

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2418,6 +2418,11 @@ class Exchange {
         return $result;
     }
 
+    // returns the version of the ccxt library, e.g. "4.5.54"
+    public function get_ccxt_version() {
+        return static::VERSION;
+    }
+
     public function check_required_dependencies() {
         if (!static::has_web3()) {
             throw new ExchangeError($this->id . ' requires web3 dependencies');

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1780,6 +1780,10 @@ class Exchange(object):
                 return error
         return result
 
+    def get_ccxt_version(self):
+        """returns the version of the ccxt library, e.g. "4.5.54" """
+        return __version__
+
     def precision_from_string(self, str):
         # support string formats like '1e-4'
         if 'e' in str or 'E' in str:

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -677,8 +677,8 @@ export default class Exchange {
     /**
      * @method
      * @name Exchange#getCcxtVersion
-     * @description returns the version of the ccxt library, e.g. "4.5.54"
-     * @returns {string} the semver version of the ccxt library
+     * @description returns the version of the ccxt library, e.g. "4.5.54", or "unknown" when the version constant is not initialized (e.g. when an exchange module is imported directly, bypassing the ccxt entry point)
+     * @returns {string} the semver version of the ccxt library, or "unknown" when unavailable
      */
     getCcxtVersion (): string {
         const staticVersion = (Exchange as any).ccxtVersion;

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -674,6 +674,17 @@ export default class Exchange {
         return encodeURIComponent (...args);
     }
 
+    /**
+     * @method
+     * @name Exchange#getCcxtVersion
+     * @description returns the version of the ccxt library, e.g. "4.5.54"
+     * @returns {string} the semver version of the ccxt library
+     */
+    getCcxtVersion (): string {
+        const staticVersion = (Exchange as any).ccxtVersion;
+        return (staticVersion === undefined) ? 'unknown' : staticVersion;
+    }
+
     checkRequiredVersion (requiredVersion, error = true) {
         let result = true;
         const [ major1, minor1, patch1 ] = requiredVersion.split ('.');

--- a/ts/src/foxbit.ts
+++ b/ts/src/foxbit.ts
@@ -2014,6 +2014,8 @@ export default class foxbit extends Exchange {
         }
         headers = {
             'Content-Type': 'application/json',
+            'X-FB-CLIENT': 'ccxt',
+            'X-FB-CLIENT-VERSION': this.getCcxtVersion (),
         };
         if (urlPath === 'private') {
             this.checkRequiredCredentials ();

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -1681,7 +1681,8 @@ class testMainClass {
             this.testModeTrade (),
             this.testBackpack (),
             this.testToobit (),
-            this.testWeex ()
+            this.testWeex (),
+            this.testFoxbit ()
         ];
         await Promise.all (promises);
         const successMessage = '[' + this.lang + '][TEST_SUCCESS] brokerId tests passed.';
@@ -2369,6 +2370,25 @@ class testMainClass {
         }
         clientOrderId = request['newClientOrderId'];
         assert (clientOrderId.startsWith (id), 'weex - newClientOrderId: ' + clientOrderId + ' for swap order does not start with id: ' + id);
+    }
+
+    async testFoxbit () {
+        const exchange = this.initOfflineExchange ('foxbit');
+        let reqHeaders = undefined;
+        const id = 'ccxt';
+        try {
+            await exchange.createOrder ('BTC/BRL', 'limit', 'buy', 1, 20000);
+        } catch (e) {
+            // we expect an error here, we're only interested in the headers
+            reqHeaders = exchange.last_request_headers;
+        }
+        assert (reqHeaders['X-FB-CLIENT'] === id, 'foxbit - id: ' + id + ' not in headers.');
+        const version = exchange.getCcxtVersion ();
+        assert (reqHeaders['X-FB-CLIENT-VERSION'] === version, 'foxbit - version: ' + version + ' not in headers.');
+        if (!isSync ()) {
+            await close (exchange);
+        }
+        return true;
     }
 }
 


### PR DESCRIPTION
## Summary
Sends `X-FB-CLIENT: ccxt` and `X-FB-CLIENT-VERSION: <ccxt version>` on every foxbit REST request so the exchange can identify and measure ccxt-originated traffic (client header approach chosen over User-Agent, which users/base code can override).

Since the library version constant was not reachable from transpiled exchange code, this adds a `getCcxtVersion()` base helper implemented above the transpile marker (hand-written per language: TS/JS, Python, PHP, C#, Go). Headers are injected in `sign()` (same pattern as bybit's `Referer`), so they take precedence over user `headers` overrides. A `testFoxbit` broker-id test asserts both headers via `last_request_headers` in all five languages.

Related: foxbit-group/kepler#2902 (server-side metric), foxbit-group/ccxt-foxbit-tests#18 (E2E tests).

## Tests run
- [x] `npm run lint` — pass (0 errors on edited files)
- [x] `npm run tsBuild` — pass
- [x] `npm run transpile` (Python + PHP) — pass
- [x] `npm run transpileCS` + `npm run buildCS` — pass (dotnet 9, 4 projects, 0 errors)
- [x] `npm run transpileGO` + `npm run buildGO` — pass (v4 + v4/pro)
- [x] request tests — 70 passed in JS, Python, PHP, C#, Go
- [x] response tests — 17 passed in JS, Python, PHP, C#, Go
- [x] id-tests (brokerId suite incl. new `testFoxbit`) — passed in JS, Python, PHP, C#, Go
- [x] `test-base-rest` — passed in JS and Python (base was touched)
- [x] Python syntax via `py_compile`; PHP via `php -l` (php:8.2 container)
- [x] Live smoke: `fetchTicker BTC/BRL` against api.foxbit.com.br — request carried both headers, 200 OK

## Notes
- Diff is source-only: `ts/src/**` + hand-written base files (`python/ccxt/base/exchange.py`, `php/Exchange.php`, `cs/ccxt/base/Exchange.Misc.cs`, `go/v4/exchange_metadata.go`, `go/v4/exchange_interface.go`). Per-exchange generated files are left to the build automation.
- The version header value comes from each language's existing version constant (`__version__`, `Exchange::VERSION`, `ccxtVersion`, `Version`), all already bumped by `vss`.
- Follow-up: upstream this to ccxt/ccxt so the headers ship in released packages — real traffic only carries them once users update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)